### PR TITLE
Rename default git branch to main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stop The Line Buildkite Plugin
 
-![Build status](https://badge.buildkite.com/dbf266ceeb831a2f0c1c0a0977d643e3327c689eaa309a4e5b.svg?branch=master)
+![Build status](https://badge.buildkite.com/dbf266ceeb831a2f0c1c0a0977d643e3327c689eaa309a4e5b.svg?branch=main)
 [![MIT License](https://img.shields.io/badge/License-MIT-brightgreen.svg)](LICENSE)
 
 A [Buildkite plugin] that stops build if a metadata key has a certain value.


### PR DESCRIPTION
#### Context

To be more welcoming and inclusive, the default git branch has been renamed to `main`.

#### Change

Update the build status badge to consider builds on the `main` branch.